### PR TITLE
Add support for unknown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,7 @@ import { Literal, Record, Runtype, Static, Union } from "runtypes";
 const NotImplemented = Union(
 	Record({ tag: Literal("instanceof") }),
 	Record({ tag: Literal("intersect") }),
-	Record({ tag: Literal("function") }),
-	Record({ tag: Literal("unknown") })
+	Record({ tag: Literal("function") })
 );
 
 const notImplementedTags = NotImplemented.alternatives.map(
@@ -40,6 +39,7 @@ export function filter<T, R extends Runtype<T>>(t: R, x: T): T {
 		case "void":
 		case "symbol":
 		case "never":
+		case "unknown":
 			return x;
 		case "array":
 			return (x as any).map((v: any) => filter(r.element, v));
@@ -102,6 +102,7 @@ export function validate<T, R extends Runtype<T>>(t: R): R {
 			case "string":
 			case "void":
 			case "symbol":
+			case "unknown":
 				return;
 			case "array":
 				return check(r.element);

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -13,6 +13,7 @@ import {
 	String,
 	Tuple,
 	Union,
+	Unknown,
 	ValidationError,
 } from "runtypes";
 
@@ -26,6 +27,7 @@ describe("FilterCheck", () => {
 		expect(FilterCheck(Number)(5)).toEqual(5);
 		expect(FilterCheck(String)("a")).toEqual("a");
 		expect(FilterCheck(Null)(null)).toEqual(null);
+		expect(FilterCheck(Unknown)({ a: "a", b: 1 })).toEqual({ a: "a", b: 1 });
 	});
 
 	it("should handle tuples", () => {


### PR DESCRIPTION
Adding support for the Unknown type. As far as I can tell Unknown in runtypes allows anything to validate, however adds no type info. If Unknown is explicitly defined it means the user is opting in to the key/property existing and seems to make sense to not filter it.