### PR TITLE
Support undefined in partials

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ they may not be safely cloned.
 - `InstanceOf`
 - `Intersect`
 - `Function`
-- `Unknown`
 
 ## Usage
 

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -45,10 +45,14 @@ describe("FilterCheck", () => {
 			Partial({
 				a: String,
 				b: String,
+				d: Array(String),
+				e: Tuple(Literal("a")),
 			})
 		);
 
-		expect(check({ a: "aaa", c: "ccc" })).toEqual({ a: "aaa" });
+		expect(check({ a: "aaa", c: "ccc", d: undefined, e: undefined })).toEqual({
+			a: "aaa",
+		});
 	});
 
 	it("should handle unions", () => {


### PR DESCRIPTION
`runtypes` allows `undefined` as a valid value for partial fields. Rather than omitting the field it leaves the value `undefined` in the result. This trips up filtering as the `tag` is not enough to tell whether the value is `undefined` and therefore things like `(undefined as any).map(...)` blow up.

```typescript

const PartialWithArray = Partial({
	a: Array(String),
});

const unchecked = {
	a: undefined,
};

const checked = PartialWithArray.check(unchecked);

// equivalent to
// const checked = {
// 	a: undefined
// }

filter(PartialWithArray, checked);
// TypeError: Cannot read property 'map' of undefined

```

Bonus: tiny readme tweak for https://github.com/kjvalencik/runtypes-filter/pull/5 ;)