### PR TITLE
Support undefined in partials

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,14 +29,14 @@ function filterInternal<T, R extends Runtype<T>>(
 	x: T,
 	parentContext: { isPartial: boolean }
 ): T {
+	if (parentContext.isPartial && x === undefined) {
+		return x;
+	}
+
 	const r = t.reflect;
 
 	if (isNotImplemented(r)) {
 		throw new Error(`Type "${r.tag}" is not filterable`);
-	}
-
-	if (parentContext.isPartial && x === undefined) {
-		return x;
 	}
 
 	const context = { isPartial: r.tag === "record" && r.isPartial };

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -49,10 +49,13 @@ describe("FilterCheck", () => {
 				b: String,
 				d: Array(String),
 				e: Tuple(Literal("a")),
+				f: Union(Literal("a"), Literal("b")),
 			})
 		);
 
-		expect(check({ a: "aaa", c: "ccc", d: undefined, e: undefined })).toEqual({
+		expect(
+			check({ a: "aaa", c: "ccc", d: undefined, e: undefined, f: undefined })
+		).toEqual({
 			a: "aaa",
 		});
 	});


### PR DESCRIPTION
Follow up to https://github.com/kjvalencik/runtypes-filter/pull/6. Need to do the check prior to calling `reflect` as the Runtype schema can be undefined in some cases.