### PR TITLE
Finish filtering on undefined optional value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,8 +81,11 @@ function filterInternal<T, R extends Runtype<T>>(
 
 			return filterInternal(<any>alt, x, context);
 		case "constraint":
-		case "optional":
 			return filterInternal(<any>r.underlying, x, context);
+		case "optional":
+			return typeof x === "undefined"
+				? x
+				: filterInternal(<any>r.underlying, x, context);
 		case "brand":
 			return filterInternal(<any>r.entity, x, context);
 		// Exhaustiveness checking

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -85,6 +85,9 @@ describe("FilterCheck", () => {
 
 		expect(checkWrapper(10)).toBe(10);
 		expect(checkWrapper(undefined)).toBeUndefined();
+		expect(() => checkWrapper(null)).toThrowErrorMatchingInlineSnapshot(
+			`"Expected number, but was null"`
+		);
 
 		const checkChain = FilterCheck(
 			Number.optional().withConstraint((n) => typeof n === "undefined" || n > 5)
@@ -92,6 +95,9 @@ describe("FilterCheck", () => {
 
 		expect(checkChain(10)).toBe(10);
 		expect(checkChain(undefined)).toBeUndefined();
+		expect(() => checkChain(null)).toThrowErrorMatchingInlineSnapshot(
+			`"Expected number, but was null"`
+		);
 
 		const checkRecord = FilterCheck(
 			Record({
@@ -102,6 +108,12 @@ describe("FilterCheck", () => {
 		expect(checkRecord({ a: 10 })).toStrictEqual({ a: 10 });
 		expect(checkRecord({})).toStrictEqual({});
 		expect(checkRecord(undefined)).toBeUndefined();
+		expect(() => checkRecord({ a: null })).toThrowErrorMatchingInlineSnapshot(
+			`"Expected number, but was null in a"`
+		);
+		expect(() => checkRecord(null)).toThrowErrorMatchingInlineSnapshot(
+			`"Expected { a?: number; }, but was null"`
+		);
 
 		const checkUnion = FilterCheck(Union(Number, Null).optional());
 

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -83,13 +83,31 @@ describe("FilterCheck", () => {
 			Optional(Number.withConstraint((n) => n > 5))
 		);
 
-		expect(checkWrapper(10)).toEqual(10);
+		expect(checkWrapper(10)).toBe(10);
+		expect(checkWrapper(undefined)).toBeUndefined();
 
 		const checkChain = FilterCheck(
 			Number.optional().withConstraint((n) => typeof n === "undefined" || n > 5)
 		);
 
-		expect(checkChain(10)).toEqual(10);
+		expect(checkChain(10)).toBe(10);
+		expect(checkChain(undefined)).toBeUndefined();
+
+		const checkRecord = FilterCheck(
+			Record({
+				a: Number.withConstraint((n) => n > 5).optional(),
+			}).optional()
+		);
+
+		expect(checkRecord({ a: 10 })).toStrictEqual({ a: 10 });
+		expect(checkRecord({})).toStrictEqual({});
+		expect(checkRecord(undefined)).toBeUndefined();
+
+		const checkUnion = FilterCheck(Union(Number, Null).optional());
+
+		expect(checkUnion(10)).toBe(10);
+		expect(checkUnion(null)).toBeNull();
+		expect(checkUnion(undefined)).toBeUndefined();
 	});
 
 	it("should handle brands", () => {


### PR DESCRIPTION
Apologies, I initially had this in #9 but thought it was unnecessary when the tests passed. Turns out my tests were insufficient.

This prevents filtering from continuing on an undefined value for an optional type, which was subsequently failing when it tried to access properties on that undefined value.