### PR TITLE
Allow runtypes@6 peer dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "runtypes-filter",
-	"version": "0.4.2",
+	"version": "0.5.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
@@ -4106,9 +4106,9 @@
 			"dev": true
 		},
 		"runtypes": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/runtypes/-/runtypes-5.2.0.tgz",
-			"integrity": "sha512-ArcmkYvNWkHrwg4Ic7St365oUGAkiIcs6vNmoRNzADv7nBhrTQC8C562TYnIV9nxxMxdmAAHsehD78xuWeYPJA==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/runtypes/-/runtypes-6.0.0.tgz",
+			"integrity": "sha512-hVBZ2S0i9MmyViSpwCU7TGFuEZxjPIeTMbhCpz59/8C3IGbPL6N03bIVALGfVWZQ+MTXORjWpWnZUP3hPyw96w==",
 			"dev": true
 		},
 		"safe-buffer": {
@@ -5133,9 +5133,9 @@
 			}
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+			"integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
 			"dev": true
 		},
 		"union-value": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,6 @@
 		"typescript": "^4.2.3"
 	},
 	"peerDependencies": {
-		"runtypes": ">= 5 < 7"
+		"runtypes": ">=5 <7"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
 		"jest": "^26.1.0",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^2.0.5",
-		"runtypes": "^5.2.0",
+		"runtypes": "^6.0.0",
 		"ts-jest": "^26.1.3",
 		"tslint": "^6.1.2",
 		"tslint-config-airbnb": "^5.11.2",
 		"tslint-config-prettier": "^1.18.0",
-		"typescript": "^3.9.7"
+		"typescript": "^4.2.3"
 	},
 	"peerDependencies": {
-		"runtypes": "^5.0.1"
+		"runtypes": ">= 5 < 7"
 	}
 }

--- a/test/filter.test.ts
+++ b/test/filter.test.ts
@@ -109,7 +109,7 @@ describe("FilterCheck", () => {
 		expect(checkRecord({})).toStrictEqual({});
 		expect(checkRecord(undefined)).toBeUndefined();
 		expect(() => checkRecord({ a: null })).toThrowErrorMatchingInlineSnapshot(
-			`"Expected number, but was null in a"`
+			`"Expected { a?: number; }, but was incompatible"`
 		);
 		expect(() => checkRecord(null)).toThrowErrorMatchingInlineSnapshot(
 			`"Expected { a?: number; }, but was null"`


### PR DESCRIPTION
I think runtypes-filter is unaffected by the breaking changes:

https://github.com/pelotom/runtypes/releases/tag/v6.0.0